### PR TITLE
Use BullMQ compliant queue name

### DIFF
--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -1,7 +1,7 @@
 import { Queue, QueueEvents, JobsOptions } from 'bullmq';
 import { getConfig } from '../config';
 
-export const TAGGING_QUEUE_NAME = 'tagging-service:jobs';
+export const TAGGING_QUEUE_NAME = 'tagging-service-jobs';
 
 export interface TaggingQueueComponents {
   queue: Queue;


### PR DESCRIPTION
## Summary
- update the BullMQ queue name constant to avoid the `:` character rejected by BullMQ 5.9+

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdff5b07d88333a61a49c20fd156b6