### PR TITLE
Add realtime monitoring dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fastify/redis": "^6.1.0",
         "@fastify/swagger": "^8.10.0",
         "@fastify/swagger-ui": "^1.9.0",
+        "@fastify/websocket": "^8.3.0",
         "better-sqlite3": "^12.2.0",
         "bullmq": "^5.8.2",
         "dotenv": "^16.4.5",
@@ -27,6 +28,7 @@
         "@types/better-sqlite3": "^7.6.5",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.30",
+        "@types/ws": "^8.5.10",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.1",
@@ -699,6 +701,22 @@
       "license": "MIT"
     },
     "node_modules/@fastify/swagger/node_modules/fastify-plugin": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
+      "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/websocket": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-8.3.1.tgz",
+      "integrity": "sha512-hsQYHHJme/kvP3ZS4v/WMUznPBVeeQHHwAoMy1LiN6m/HuPfbdXq1MBJ4Nt8qX1YI+eVbog4MnOsU7MTozkwYA==",
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^4.0.0",
+        "ws": "^8.0.0"
+      }
+    },
+    "node_modules/@fastify/websocket/node_modules/fastify-plugin": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
       "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==",
@@ -1386,6 +1404,16 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -5876,6 +5904,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fastify/redis": "^6.1.0",
     "@fastify/swagger": "^8.10.0",
     "@fastify/swagger-ui": "^1.9.0",
+    "@fastify/websocket": "^8.3.0",
     "better-sqlite3": "^12.2.0",
     "bullmq": "^5.8.2",
     "dotenv": "^16.4.5",
@@ -34,6 +35,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@types/ws": "^8.5.10"
   }
 }

--- a/src/server/dashboardHub.ts
+++ b/src/server/dashboardHub.ts
@@ -1,0 +1,199 @@
+import type { Queue } from 'bullmq';
+import type WebSocket from 'ws';
+import { getJobStatusCounts, listRecentRuns, type RecentJobRunRecord } from '../db/jobStore';
+import { logger } from '../lib/logger';
+
+interface DashboardSummary {
+  totalJobs: number;
+  queuedJobs: number;
+  runningJobs: number;
+  succeededJobs: number;
+  failedJobs: number;
+}
+
+interface QueueCounts {
+  waiting: number;
+  active: number;
+  completed: number;
+  failed: number;
+  delayed: number;
+}
+
+export type DashboardEventType =
+  | 'repository-event'
+  | 'job-enqueued'
+  | 'job-started'
+  | 'job-completed'
+  | 'job-failed';
+
+export interface DashboardEvent {
+  id: number;
+  timestamp: string;
+  type: DashboardEventType;
+  message: string;
+  repositoryId?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface DashboardSnapshot {
+  generatedAt: string;
+  summary: DashboardSummary;
+  queue: QueueCounts;
+  events: DashboardEvent[];
+}
+
+export interface RepositoryEventPayload {
+  eventName: string;
+  repositoryId: string;
+  ingestStatus?: string;
+}
+
+const MAX_EVENTS = 50;
+
+export class DashboardHub {
+  private clients = new Set<WebSocket>();
+  private events: DashboardEvent[] = [];
+  private snapshot: DashboardSnapshot = {
+    generatedAt: new Date().toISOString(),
+    summary: {
+      totalJobs: 0,
+      queuedJobs: 0,
+      runningJobs: 0,
+      succeededJobs: 0,
+      failedJobs: 0
+    },
+    queue: {
+      waiting: 0,
+      active: 0,
+      completed: 0,
+      failed: 0,
+      delayed: 0
+    },
+    events: []
+  };
+  private nextEventId = 1;
+
+  constructor(private readonly queue: Queue) {}
+
+  async bootstrap(): Promise<void> {
+    const recentRuns = listRecentRuns(MAX_EVENTS).reverse();
+    for (const run of recentRuns) {
+      const timestamp = run.completed_at ?? run.started_at;
+      const type: DashboardEventType = run.status === 'failed' ? 'job-failed' : 'job-completed';
+      const message =
+        run.status === 'failed'
+          ? `Run ${run.id} failed${run.error_message ? `: ${run.error_message}` : ''}`
+          : `Run ${run.id} succeeded`;
+      this.pushEvent({
+        type,
+        timestamp,
+        repositoryId: run.repository_id,
+        message,
+        details: buildRunDetails(run)
+      });
+    }
+
+    await this.refreshSnapshot();
+  }
+
+  addClient(socket: WebSocket): void {
+    this.clients.add(socket);
+    socket.on('close', () => {
+      this.clients.delete(socket);
+    });
+    socket.on('error', (err) => {
+      logger.warn({ err }, 'Dashboard client socket error');
+      this.clients.delete(socket);
+    });
+    socket.send(JSON.stringify({ type: 'snapshot', payload: this.snapshot }));
+  }
+
+  async refreshSnapshot(): Promise<void> {
+    const statusCounts = getJobStatusCounts();
+    const jobCounts = await this.queue.getJobCounts('waiting', 'active', 'completed', 'failed', 'delayed');
+
+    this.snapshot = {
+      generatedAt: new Date().toISOString(),
+      summary: {
+        totalJobs: statusCounts.total,
+        queuedJobs: statusCounts.queued,
+        runningJobs: statusCounts.running,
+        succeededJobs: statusCounts.succeeded,
+        failedJobs: statusCounts.failed
+      },
+      queue: {
+        waiting: jobCounts.waiting ?? 0,
+        active: jobCounts.active ?? 0,
+        completed: jobCounts.completed ?? 0,
+        failed: jobCounts.failed ?? 0,
+        delayed: jobCounts.delayed ?? 0
+      },
+      events: [...this.events]
+    };
+
+    this.broadcast();
+  }
+
+  async recordRepositoryEvent(event: RepositoryEventPayload): Promise<void> {
+    this.pushEvent({
+      type: 'repository-event',
+      timestamp: new Date().toISOString(),
+      repositoryId: event.repositoryId,
+      message: `${event.eventName} (${event.ingestStatus ?? 'unknown'})`
+    });
+    await this.refreshSnapshot();
+  }
+
+  async recordJobEvent(
+    type: Exclude<DashboardEventType, 'repository-event'>,
+    data: {
+      repositoryId?: string;
+      jobId?: string;
+      message: string;
+      details?: Record<string, unknown>;
+    }
+  ): Promise<void> {
+    this.pushEvent({
+      type,
+      timestamp: new Date().toISOString(),
+      repositoryId: data.repositoryId,
+      message: data.message,
+      details: data.details
+    });
+    await this.refreshSnapshot();
+  }
+
+  private broadcast(): void {
+    const payload = JSON.stringify({ type: 'snapshot', payload: this.snapshot });
+    for (const socket of this.clients) {
+      if (socket.readyState !== socket.OPEN) {
+        this.clients.delete(socket);
+        continue;
+      }
+      try {
+        socket.send(payload);
+      } catch (err) {
+        logger.warn({ err }, 'Failed to broadcast dashboard snapshot');
+        this.clients.delete(socket);
+      }
+    }
+  }
+
+  private pushEvent(event: Omit<DashboardEvent, 'id'>): void {
+    const entry: DashboardEvent = { id: this.nextEventId++, ...event };
+    this.events = [entry, ...this.events].slice(0, MAX_EVENTS);
+  }
+}
+
+function buildRunDetails(run: RecentJobRunRecord): Record<string, unknown> {
+  return {
+    jobRunId: run.id,
+    startedAt: run.started_at,
+    completedAt: run.completed_at,
+    status: run.status,
+    latencyMs: run.latency_ms,
+    promptTokens: run.prompt_tokens,
+    completionTokens: run.completion_tokens,
+    costUsd: run.cost_usd
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,8 @@ import type { FastifyBaseLogger } from 'fastify';
 import fastifySensible from 'fastify-sensible';
 import swagger from '@fastify/swagger';
 import swaggerUi from '@fastify/swagger-ui';
+import websocketPlugin from '@fastify/websocket';
+import type { SocketStream } from '@fastify/websocket';
 import { serializerCompiler, validatorCompiler, ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { getConfig } from '../config';
@@ -11,6 +13,7 @@ import { buildQueueComponents, taggingJobId } from '../queue';
 import { EventSubscriber } from '../events/subscriber';
 import { Scheduler } from '../scheduler';
 import { runHealthChecks } from './health';
+import { DashboardHub } from './dashboardHub';
 import {
   countJobs,
   getAssignmentsForRun,
@@ -31,14 +34,93 @@ async function main(): Promise<void> {
   const { queue, queueEvents } = buildQueueComponents();
   await queue.waitUntilReady();
   await queueEvents.waitUntilReady();
+  const dashboard = new DashboardHub(queue);
+  await dashboard.bootstrap();
+
+  const recordQueueTransition = async (
+    type: 'job-enqueued' | 'job-started' | 'job-completed' | 'job-failed',
+    jobId: string | number | null | undefined,
+    summary: string,
+    details?: Record<string, unknown>
+  ) => {
+    const normalizedJobId = jobId != null ? String(jobId) : undefined;
+    let repositoryId: string | undefined;
+    let jobDetails: Record<string, unknown> | undefined;
+
+    if (normalizedJobId) {
+      try {
+        const job = await queue.getJob(normalizedJobId);
+        if (job) {
+          const data = job.data as Partial<TaggingJobData>;
+          repositoryId = data.repositoryId;
+          jobDetails = {
+            attemptsMade: job.attemptsMade,
+            processedOn: job.processedOn,
+            finishedOn: job.finishedOn,
+            data
+          };
+        }
+      } catch (error) {
+        logger.warn({ jobId: normalizedJobId, error }, 'Failed to load job for dashboard event');
+      }
+    }
+
+    const message = repositoryId
+      ? `Repository ${repositoryId} ${summary}`
+      : `Job ${normalizedJobId ?? 'unknown'} ${summary}`;
+
+    const mergedDetails: Record<string, unknown> | undefined = (() => {
+      if (!details && !jobDetails) {
+        return undefined;
+      }
+      return {
+        ...(details ?? {}),
+        ...(jobDetails ? { job: jobDetails } : {})
+      };
+    })();
+
+    await dashboard.recordJobEvent(type, {
+      repositoryId,
+      jobId: normalizedJobId,
+      message,
+      details: mergedDetails
+    });
+  };
+
+  queueEvents.on('waiting', ({ jobId }) => {
+    recordQueueTransition('job-enqueued', jobId, 'was enqueued').catch((error) => {
+      logger.warn({ jobId, error }, 'Failed to record enqueued job event');
+    });
+  });
+  queueEvents.on('active', ({ jobId }) => {
+    recordQueueTransition('job-started', jobId, 'started processing').catch((error) => {
+      logger.warn({ jobId, error }, 'Failed to record started job event');
+    });
+  });
+  queueEvents.on('completed', ({ jobId, returnvalue }) => {
+    recordQueueTransition('job-completed', jobId, 'completed successfully', {
+      returnValue: returnvalue
+    }).catch((error) => {
+      logger.warn({ jobId, error }, 'Failed to record completed job event');
+    });
+  });
   queueEvents.on('failed', ({ jobId, failedReason }) => {
     logger.error({ jobId, failedReason }, 'Queue job failed');
+    recordQueueTransition(
+      'job-failed',
+      jobId,
+      failedReason ? `failed: ${failedReason}` : 'failed',
+      failedReason ? { failedReason } : undefined
+    ).catch((error) => {
+      logger.warn({ jobId, error }, 'Failed to record failed job event');
+    });
   });
 
-  const eventSubscriber = new EventSubscriber(queue);
+  const eventSubscriber = new EventSubscriber(queue, (event) => dashboard.recordRepositoryEvent(event));
   const manualScheduler = new Scheduler(queue);
 
   await app.register(fastifySensible);
+  await app.register(websocketPlugin);
   await app.register(swagger, {
     openapi: {
       info: {
@@ -53,6 +135,14 @@ async function main(): Promise<void> {
     uiConfig: {
       docExpansion: 'list'
     }
+  });
+
+  app.get('/', async (_request, reply) => {
+    return reply.type('text/html').send(buildDashboardHtml());
+  });
+
+  app.get('/ws', { websocket: true }, (connection: SocketStream) => {
+    dashboard.addClient(connection.socket);
   });
 
   const jobsQuerySchema = z.object({
@@ -274,6 +364,432 @@ async function main(): Promise<void> {
 
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
+}
+
+function buildDashboardHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tagging Service Dashboard</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #0f172a;
+        --surface: rgba(15, 23, 42, 0.8);
+        --surface-light: rgba(255, 255, 255, 0.08);
+        --text: #f8fafc;
+        --muted: #94a3b8;
+        --accent: #38bdf8;
+        --success: #22c55e;
+        --warning: #facc15;
+        --danger: #f87171;
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, #1e293b, #020617 70%);
+        color: var(--text);
+      }
+
+      .dashboard {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 32px 16px 48px;
+      }
+
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin-bottom: 32px;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 2rem;
+        letter-spacing: 0.02em;
+      }
+
+      .status-line {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+
+      .connection-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 8px;
+        border-radius: 12px;
+        background: var(--surface-light);
+      }
+
+      .connection-status::before {
+        content: '';
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--warning);
+      }
+
+      .connection-status.connected::before {
+        background: var(--success);
+      }
+
+      .connection-status.disconnected::before {
+        background: var(--danger);
+      }
+
+      .cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 16px;
+        margin-bottom: 32px;
+      }
+
+      .card {
+        background: var(--surface);
+        backdrop-filter: blur(18px);
+        border-radius: 16px;
+        padding: 20px;
+        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.35);
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .metric-label {
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+
+      .metric-value {
+        font-size: 2.25rem;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+
+      .event-stream {
+        background: var(--surface);
+        backdrop-filter: blur(18px);
+        border-radius: 16px;
+        padding: 20px;
+        box-shadow: 0 8px 32px rgba(15, 23, 42, 0.4);
+      }
+
+      .event-stream h2 {
+        margin: 0 0 16px;
+        font-size: 1.4rem;
+      }
+
+      #event-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        max-height: 420px;
+        overflow-y: auto;
+      }
+
+      #event-list li {
+        border-left: 3px solid transparent;
+        padding: 12px 16px;
+        border-radius: 12px;
+        background: rgba(15, 23, 42, 0.65);
+      }
+
+      #event-list li.event-repository-event {
+        border-color: var(--accent);
+      }
+
+      #event-list li.event-job-enqueued {
+        border-color: var(--warning);
+      }
+
+      #event-list li.event-job-started {
+        border-color: var(--accent);
+      }
+
+      #event-list li.event-job-completed {
+        border-color: var(--success);
+      }
+
+      #event-list li.event-job-failed {
+        border-color: var(--danger);
+      }
+
+      .event-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 6px;
+      }
+
+      .event-type {
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 0.75rem;
+        color: var(--muted);
+      }
+
+      .event-time {
+        font-size: 0.85rem;
+        color: var(--muted);
+      }
+
+      .event-message {
+        font-size: 1rem;
+        line-height: 1.4;
+      }
+
+      .event-details {
+        margin-top: 8px;
+        font-size: 0.8rem;
+        color: var(--muted);
+        background: rgba(15, 23, 42, 0.55);
+        padding: 8px;
+        border-radius: 8px;
+        overflow-x: auto;
+      }
+
+      @media (max-width: 640px) {
+        .dashboard {
+          padding: 24px 12px 36px;
+        }
+
+        header h1 {
+          font-size: 1.6rem;
+        }
+
+        .metric-value {
+          font-size: 1.8rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="dashboard">
+      <header>
+        <h1>Tagging Service Monitor</h1>
+        <div class="status-line">
+          <span id="connection-status" class="connection-status">Connecting…</span>
+          <span>Last update: <strong id="updated-at">—</strong></span>
+        </div>
+      </header>
+      <section class="cards" aria-label="Job summary metrics">
+        <article class="card" data-metric="totalJobs">
+          <span class="metric-label">Tracked Repositories</span>
+          <span class="metric-value">0</span>
+        </article>
+        <article class="card" data-metric="queuedJobs">
+          <span class="metric-label">Queued Jobs</span>
+          <span class="metric-value">0</span>
+        </article>
+        <article class="card" data-metric="runningJobs">
+          <span class="metric-label">Running Jobs</span>
+          <span class="metric-value">0</span>
+        </article>
+        <article class="card" data-metric="succeededJobs">
+          <span class="metric-label">Succeeded Jobs</span>
+          <span class="metric-value">0</span>
+        </article>
+        <article class="card" data-metric="failedJobs">
+          <span class="metric-label">Failed Jobs</span>
+          <span class="metric-value">0</span>
+        </article>
+      </section>
+      <section class="cards" aria-label="Queue metrics">
+        <article class="card" data-queue="waiting">
+          <span class="metric-label">Waiting</span>
+          <span class="metric-value">0</span>
+        </article>
+        <article class="card" data-queue="active">
+          <span class="metric-label">Active</span>
+          <span class="metric-value">0</span>
+        </article>
+        <article class="card" data-queue="completed">
+          <span class="metric-label">Completed (retained)</span>
+          <span class="metric-value">0</span>
+        </article>
+        <article class="card" data-queue="failed">
+          <span class="metric-label">Failed (retained)</span>
+          <span class="metric-value">0</span>
+        </article>
+        <article class="card" data-queue="delayed">
+          <span class="metric-label">Delayed</span>
+          <span class="metric-value">0</span>
+        </article>
+      </section>
+      <section class="event-stream" aria-label="Event stream">
+        <h2>Recent Activity</h2>
+        <ul id="event-list" aria-live="polite"></ul>
+      </section>
+    </div>
+    <script>
+      (() => {
+        const statusEl = document.getElementById('connection-status');
+        const updatedAtEl = document.getElementById('updated-at');
+        const summaryEls = {
+          totalJobs: document.querySelector('[data-metric="totalJobs"] .metric-value'),
+          queuedJobs: document.querySelector('[data-metric="queuedJobs"] .metric-value'),
+          runningJobs: document.querySelector('[data-metric="runningJobs"] .metric-value'),
+          succeededJobs: document.querySelector('[data-metric="succeededJobs"] .metric-value'),
+          failedJobs: document.querySelector('[data-metric="failedJobs"] .metric-value')
+        };
+        const queueEls = {
+          waiting: document.querySelector('[data-queue="waiting"] .metric-value'),
+          active: document.querySelector('[data-queue="active"] .metric-value'),
+          completed: document.querySelector('[data-queue="completed"] .metric-value'),
+          failed: document.querySelector('[data-queue="failed"] .metric-value'),
+          delayed: document.querySelector('[data-queue="delayed"] .metric-value')
+        };
+        const eventsList = document.getElementById('event-list');
+
+        function setStatus(text, state) {
+          statusEl.textContent = text;
+          statusEl.classList.remove('connected', 'disconnected', 'connecting');
+          if (state) {
+            statusEl.classList.add(state);
+          }
+        }
+
+        function formatTimestamp(value) {
+          if (!value) {
+            return '—';
+          }
+          const date = new Date(value);
+          if (Number.isNaN(date.getTime())) {
+            return value;
+          }
+          return date.toLocaleString();
+        }
+
+        function formatType(type) {
+          return (
+            {
+              'repository-event': 'Repository Event',
+              'job-enqueued': 'Job Enqueued',
+              'job-started': 'Job Started',
+              'job-completed': 'Job Completed',
+              'job-failed': 'Job Failed'
+            }[type] || type
+          );
+        }
+
+        function renderEvents(events) {
+          eventsList.innerHTML = '';
+          (events || []).forEach((event) => {
+            const item = document.createElement('li');
+            item.classList.add('event', 'event-' + event.type);
+
+            const header = document.createElement('div');
+            header.className = 'event-header';
+
+            const typeEl = document.createElement('span');
+            typeEl.className = 'event-type';
+            typeEl.textContent = formatType(event.type);
+
+            const timeEl = document.createElement('span');
+            timeEl.className = 'event-time';
+            timeEl.textContent = formatTimestamp(event.timestamp);
+
+            header.appendChild(typeEl);
+            header.appendChild(timeEl);
+            item.appendChild(header);
+
+            const messageEl = document.createElement('div');
+            messageEl.className = 'event-message';
+            const parts = [];
+            if (event.repositoryId) {
+              parts.push(event.repositoryId);
+            }
+            parts.push(event.message);
+            messageEl.textContent = parts.join(' — ');
+            item.appendChild(messageEl);
+
+            if (event.details && Object.keys(event.details).length > 0) {
+              const detailsEl = document.createElement('pre');
+              detailsEl.className = 'event-details';
+              detailsEl.textContent = JSON.stringify(event.details, null, 2);
+              item.appendChild(detailsEl);
+            }
+
+            eventsList.appendChild(item);
+          });
+        }
+
+        function updateSnapshot(snapshot) {
+          if (!snapshot) {
+            return;
+          }
+          updatedAtEl.textContent = formatTimestamp(snapshot.generatedAt);
+
+          if (snapshot.summary) {
+            Object.entries(summaryEls).forEach(([key, el]) => {
+              if (!el) return;
+              const value = snapshot.summary[key] ?? 0;
+              el.textContent = Number.isFinite(value) ? value.toLocaleString() : String(value);
+            });
+          }
+
+          if (snapshot.queue) {
+            Object.entries(queueEls).forEach(([key, el]) => {
+              if (!el) return;
+              const value = snapshot.queue[key] ?? 0;
+              el.textContent = Number.isFinite(value) ? value.toLocaleString() : String(value);
+            });
+          }
+
+          renderEvents(snapshot.events);
+        }
+
+        function connect() {
+          setStatus('Connecting…', 'connecting');
+          const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+          const socket = new WebSocket(protocol + '://' + window.location.host + '/ws');
+
+          socket.addEventListener('open', () => {
+            setStatus('Connected', 'connected');
+          });
+
+          socket.addEventListener('close', () => {
+            setStatus('Disconnected – retrying…', 'disconnected');
+            setTimeout(connect, 2000);
+          });
+
+          socket.addEventListener('error', () => {
+            socket.close();
+          });
+
+          socket.addEventListener('message', (event) => {
+            try {
+              const payload = JSON.parse(event.data);
+              if (payload && payload.type === 'snapshot') {
+                updateSnapshot(payload.payload);
+              }
+            } catch (err) {
+              console.error('Failed to parse dashboard payload', err);
+            }
+          });
+        }
+
+        connect();
+      })();
+    </script>
+  </body>
+</html>`;
 }
 
 void main().catch(async (err) => {


### PR DESCRIPTION
## Summary
- add a dashboard hub that aggregates job metrics, queue counts, and recent events for websocket clients
- expose a websocket endpoint and serve a monitoring dashboard UI at the root route to stream live updates
- capture repository events and job lifecycle transitions so the dashboard shows realtime activity and status

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce1b1b739c8333a6d97da470260bb6